### PR TITLE
Support 280 character tweets

### DIFF
--- a/src/jquery.tweetable.js
+++ b/src/jquery.tweetable.js
@@ -76,9 +76,9 @@
 	      	if (tweetText == "" || tweetText === undefined)
 	    		var tweetText = $e.text();
 
-	    	// Let's go ahead and be a stickler about enforcing that 140-char limit.
-	    	if (tweetText.length > 140) {
-	    		console.error("That's, like, more than 140 characters.  Do you even *get* Twitter?")
+	    	// Let's go ahead and be a stickler about enforcing that 280-char limit.
+	    	if (tweetText.length > 280) {
+	    		console.error("That's, like, more than 280 characters.  Do you even *get* Twitter?")
 	    		return $e;
 	    	}
 


### PR DESCRIPTION
Regretfully, Twitter now supports 280 character tweets. Sad as it may be, this is the brave new world we live in and this pull request updates jquery.tweetable to support this as well.